### PR TITLE
SECURITY-1324 Hide unbound version

### DIFF
--- a/templates/unbound.conf.epp
+++ b/templates/unbound.conf.epp
@@ -13,6 +13,10 @@ server:
         logfile: <%= $profile_dns_cache::log_file %>
         log-queries: no
         statistics-interval: 3600
+        <%- if !$profile_dns_cache::access_control.empty { -%>
+        hide-identity: yes
+        hide-version: yes
+        <%- } -%>
 	# Begin local-zone entries (to prevent Unbound)
 	# from doing reverse DNS lookups for local IP
 	# ranges using the wrong servers.


### PR DESCRIPTION
Vetting in SECURITY-1324 has requested that we hide unbound version
number. This only matters when unbound is listening as a server.
Setup unbound.conf.epp to add hide directives to the config file
if the server is being setup as a server