### PR TITLE
SECURITY-1502 Optionally disable unbound setting harden-dnssec-stripped

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Installs unbound and configures DNS resolution, optionally sets up an unbound se
  
 ### class profile_dns_cache (
 -  # PARAMETERS
--  String $log_file,
--  String $local_domain,
--  Array $search_domains,
--  Array $forward_servers,
--  Array $backup_dns_servers,
--  Array $reverse_overrides,
--  Array $interfaces,
--  Array $access_control,
+-  Array   $access_control,
+-  Array   $backup_dns_servers,
+-  Boolean $enable_harden_dnssec_stripped,
+-  Array   $forward_servers,
+-  Array   $interfaces,
+-  String  $local_domain,
+-  String  $log_file,
+-  Array   $reverse_overrides,
+-  Array   $search_domains,
 
 See also: [REFERENCE.md](REFERENCE.md)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -31,76 +31,15 @@ include profile_dns_cache
 
 The following parameters are available in the `profile_dns_cache` class:
 
-* [`log_file`](#log_file)
-* [`local_domain`](#local_domain)
-* [`search_domains`](#search_domains)
-* [`forward_servers`](#forward_servers)
-* [`backup_dns_servers`](#backup_dns_servers)
-* [`reverse_overrides`](#reverse_overrides)
-* [`interfaces`](#interfaces)
 * [`access_control`](#access_control)
-
-##### <a name="log_file"></a>`log_file`
-
-Data type: `String`
-
-Path to unbound log file, e.g., '/var/log/unbound.log'
-
-##### <a name="local_domain"></a>`local_domain`
-
-Data type: `String`
-
-(optional) sets domain in resolv.conf, e.g., 'yahoo.com', or 'none' for none
-
-##### <a name="search_domains"></a>`search_domains`
-
-Data type: `Array`
-
-Sets search domains in resolv.conf, e.g., 'google.com'
-
-##### <a name="forward_servers"></a>`forward_servers`
-
-Data type: `Array`
-
-List of servers unbound will forward to
-
-Format is array of hashes of the form:
-[ { server => 'IP_ADDRESS', comment => 'COMMENT' } , ... ]
-
-##### <a name="backup_dns_servers"></a>`backup_dns_servers`
-
-Data type: `Array`
-
-Sets backup nameserver(s) in resolv.conf
-
-Format is array of hashes of the form:
-[ { server => 'IP_ADDRESS', comment => 'COMMENT' } , ... ]
-
-Only the first two will be considered, any more will be ignored
-as the max num of nameserver entries for resolv.conf is currently
-3 and the first will be Unbound on the local server,
-see http://man7.org/linux/man-pages/man5/resolv.conf.5.html
-
-##### <a name="reverse_overrides"></a>`reverse_overrides`
-
-Data type: `Array`
-
-Sets up an unbound local-zone and accompanying stub-zone to serve as an override
-for reverse dns lookups
-
-Array of arrays of the form:
-[ [ 'STUB_ZONE_NAME', 'STUB-ADDR_FOR_ZONE' ] , ... ]
-
-Each stub-zone can have one or more stub-addr(s)
-
-##### <a name="interfaces"></a>`interfaces`
-
-Data type: `Array`
-
-Sets up unbound to listen for incoming connections from external hosts on
-the interface(s) specified.
-
-Format is array of one or more ip addresses
+* [`backup_dns_servers`](#backup_dns_servers)
+* [`enable_harden_dnssec_stripped`](#enable_harden_dnssec_stripped)
+* [`forward_servers`](#forward_servers)
+* [`interfaces`](#interfaces)
+* [`local_domain`](#local_domain)
+* [`log_file`](#log_file)
+* [`reverse_overrides`](#reverse_overrides)
+* [`search_domains`](#search_domains)
 
 ##### <a name="access_control"></a>`access_control`
 
@@ -130,6 +69,81 @@ Example hiera config
     - net: "10.0.0.0/8"
       action: "deny"
 ```
+
+##### <a name="backup_dns_servers"></a>`backup_dns_servers`
+
+Data type: `Array`
+
+Sets backup nameserver(s) in resolv.conf
+
+Format is array of hashes of the form:
+[ { server => 'IP_ADDRESS', comment => 'COMMENT' } , ... ]
+
+Only the first two will be considered, any more will be ignored
+as the max num of nameserver entries for resolv.conf is currently
+3 and the first will be Unbound on the local server,
+see http://man7.org/linux/man-pages/man5/resolv.conf.5.html
+
+##### <a name="enable_harden_dnssec_stripped"></a>`enable_harden_dnssec_stripped`
+
+Data type: `Boolean`
+
+Sets the unbound.conf global setting 'harden-dnssec-stripped' to yes or no
+
+Default for unbound.conf is yes, so you will only see this config setting
+in unbound.conf if you set it to false in hiera
+
+Note that in almost all cases you should leave this at the default of true, otherwise
+you weaken DNSSEC. Would only need it if you point to DNS servers that don't offer
+all/any DNSSEC protections
+
+##### <a name="forward_servers"></a>`forward_servers`
+
+Data type: `Array`
+
+List of servers unbound will forward to
+
+Format is array of hashes of the form:
+[ { server => 'IP_ADDRESS', comment => 'COMMENT' } , ... ]
+
+##### <a name="interfaces"></a>`interfaces`
+
+Data type: `Array`
+
+Sets up unbound to listen for incoming connections from external hosts on
+the interface(s) specified.
+
+Format is array of one or more ip addresses
+
+##### <a name="local_domain"></a>`local_domain`
+
+Data type: `String`
+
+(optional) sets domain in resolv.conf, e.g., 'yahoo.com', or 'none' for none
+
+##### <a name="log_file"></a>`log_file`
+
+Data type: `String`
+
+Path to unbound log file, e.g., '/var/log/unbound.log'
+
+##### <a name="reverse_overrides"></a>`reverse_overrides`
+
+Data type: `Array`
+
+Sets up an unbound local-zone and accompanying stub-zone to serve as an override
+for reverse dns lookups
+
+Array of arrays of the form:
+[ [ 'STUB_ZONE_NAME', 'STUB-ADDR_FOR_ZONE' ] , ... ]
+
+Each stub-zone can have one or more stub-addr(s)
+
+##### <a name="search_domains"></a>`search_domains`
+
+Data type: `Array`
+
+Sets search domains in resolv.conf, e.g., 'google.com'
 
 ### <a name="profile_dns_cacheconfig"></a>`profile_dns_cache::config`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,17 +1,6 @@
 ---
 
-profile_dns_cache::log_file: "/var/log/unbound.log"
-profile_dns_cache::local_domain: "ncsa.illinois.edu"
-profile_dns_cache::interfaces: []
 profile_dns_cache::access_control: []
-profile_dns_cache::search_domains:
-  - "ncsa.illinois.edu"
-  - "internal.ncsa.edu"
-profile_dns_cache::forward_servers:
-  - server: "141.142.2.2"
-    comment: "NCSA primary"
-  - server: "141.142.230.144"
-    comment: "NCSA secondary"
 profile_dns_cache::backup_dns_servers:
   - server: "141.142.2.2"
     comment: "NCSA primary"
@@ -19,6 +8,15 @@ profile_dns_cache::backup_dns_servers:
     comment: "NCSA secondary"
 # - server: "130.126.2.131"
 #   comment: "campus DNS"
+profile_dns_cache::enable_harden_dnssec_stripped: true
+profile_dns_cache::forward_servers:
+  - server: "141.142.2.2"
+    comment: "NCSA primary"
+  - server: "141.142.230.144"
+    comment: "NCSA secondary"
+profile_dns_cache::interfaces: []
+profile_dns_cache::local_domain: "ncsa.illinois.edu"
+profile_dns_cache::log_file: "/var/log/unbound.log"
 profile_dns_cache::reverse_overrides:
   - ["192.10.in-addr.arpa.", "130.126.2.131"]
   - ["193.10.in-addr.arpa.", "130.126.2.131"]
@@ -101,3 +99,6 @@ profile_dns_cache::reverse_overrides:
   - ["29.172.in-addr.arpa.", "141.142.2.2", "141.142.230.144"]
   - ["30.172.in-addr.arpa.", "141.142.2.2", "141.142.230.144"]
   - ["31.172.in-addr.arpa.", "141.142.2.2", "141.142.230.144"]
+profile_dns_cache::search_domains:
+  - "ncsa.illinois.edu"
+  - "internal.ncsa.edu"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,47 +5,6 @@
 # @example
 #   include profile_dns_cache
 #
-# @param log_file
-#   Path to unbound log file, e.g., '/var/log/unbound.log'
-#
-# @param local_domain
-#   (optional) sets domain in resolv.conf, e.g., 'yahoo.com', or 'none' for none
-#
-# @param search_domains
-#   Sets search domains in resolv.conf, e.g., 'google.com'
-#
-# @param forward_servers
-#   List of servers unbound will forward to
-#
-#   Format is array of hashes of the form:
-#   [ { server => 'IP_ADDRESS', comment => 'COMMENT' } , ... ]
-#
-# @param backup_dns_servers
-#   Sets backup nameserver(s) in resolv.conf
-#   
-#   Format is array of hashes of the form:
-#   [ { server => 'IP_ADDRESS', comment => 'COMMENT' } , ... ]
-#   
-#   Only the first two will be considered, any more will be ignored
-#   as the max num of nameserver entries for resolv.conf is currently
-#   3 and the first will be Unbound on the local server,
-#   see http://man7.org/linux/man-pages/man5/resolv.conf.5.html
-#
-# @param reverse_overrides
-#   Sets up an unbound local-zone and accompanying stub-zone to serve as an override
-#   for reverse dns lookups
-#
-#   Array of arrays of the form:
-#   [ [ 'STUB_ZONE_NAME', 'STUB-ADDR_FOR_ZONE' ] , ... ]
-#
-#   Each stub-zone can have one or more stub-addr(s) 
-#
-# @param interfaces
-#   Sets up unbound to listen for incoming connections from external hosts on
-#   the interface(s) specified.
-#
-#   Format is array of one or more ip addresses
-#
 # @param access_control
 #   Configures access-control statements in unbound config. Used to control external access
 #   when a host is setup to be an unbound server
@@ -72,16 +31,68 @@
 #         action: "deny"
 #   ```
 #
+# @param backup_dns_servers
+#   Sets backup nameserver(s) in resolv.conf
+#   
+#   Format is array of hashes of the form:
+#   [ { server => 'IP_ADDRESS', comment => 'COMMENT' } , ... ]
+#   
+#   Only the first two will be considered, any more will be ignored
+#   as the max num of nameserver entries for resolv.conf is currently
+#   3 and the first will be Unbound on the local server,
+#   see http://man7.org/linux/man-pages/man5/resolv.conf.5.html
+#
+# @param enable_harden_dnssec_stripped
+#   Sets the unbound.conf global setting 'harden-dnssec-stripped' to yes or no
+#
+#   Default for unbound.conf is yes, so you will only see this config setting
+#   in unbound.conf if you set it to false in hiera
+#
+#   Note that in almost all cases you should leave this at the default of true, otherwise
+#   you weaken DNSSEC. Would only need it if you point to DNS servers that don't offer
+#   all/any DNSSEC protections
+#
+# @param forward_servers
+#   List of servers unbound will forward to
+#
+#   Format is array of hashes of the form:
+#   [ { server => 'IP_ADDRESS', comment => 'COMMENT' } , ... ]
+#
+# @param interfaces
+#   Sets up unbound to listen for incoming connections from external hosts on
+#   the interface(s) specified.
+#
+#   Format is array of one or more ip addresses
+#
+# @param local_domain
+#   (optional) sets domain in resolv.conf, e.g., 'yahoo.com', or 'none' for none
+#
+# @param log_file
+#   Path to unbound log file, e.g., '/var/log/unbound.log'
+#
+# @param reverse_overrides
+#   Sets up an unbound local-zone and accompanying stub-zone to serve as an override
+#   for reverse dns lookups
+#
+#   Array of arrays of the form:
+#   [ [ 'STUB_ZONE_NAME', 'STUB-ADDR_FOR_ZONE' ] , ... ]
+#
+#   Each stub-zone can have one or more stub-addr(s) 
+#
+# @param search_domains
+#   Sets search domains in resolv.conf, e.g., 'google.com'
+#
 class profile_dns_cache (
   # PARAMETERS
-  String $log_file,
-  String $local_domain,
-  Array $search_domains,
-  Array $forward_servers,
-  Array $backup_dns_servers,
-  Array $reverse_overrides,
-  Array $interfaces,
-  Array $access_control,
+  Array   $access_control,
+  Array   $backup_dns_servers,
+  Boolean $enable_harden_dnssec_stripped,
+  Array   $forward_servers,
+  Array   $interfaces,
+  String  $local_domain,
+  String  $log_file,
+  Array   $reverse_overrides,
+  Array   $search_domains,
 )
 {
 

--- a/templates/unbound.conf.epp
+++ b/templates/unbound.conf.epp
@@ -17,6 +17,9 @@ server:
         hide-identity: yes
         hide-version: yes
         <%- } -%>
+        <%- if !$profile_dns_cache::enable_harden_dnssec_stripped { -%>
+        harden-dnssec-stripped: no
+        <%- } -%>
 	# Begin local-zone entries (to prevent Unbound)
 	# from doing reverse DNS lookups for local IP
 	# ranges using the wrong servers.


### PR DESCRIPTION
Add option to disable unbound's global config setting 'harden-dnssec-stripped' with the new hiera value profile_dns_cache::enable_harden_dnssec_stripped

This value defaults to true, which is what everyone should be using. Only set this to false when nodes point to a DNS server that doesn't support some/all DNSSEC features

The default setting in unbound.conf is to have this enabled, so when enable_harden_dnssec_stripped is true you will not see any edits to the unbound.conf file