### PR TITLE
SVCPLAN-1814: resolv.conf managed by unbound, not NetworkManager

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,18 +6,18 @@
 
 ### Classes
 
-* [`profile_dns_cache`](#profile_dns_cache): Configures /etc/resolv.conf and installs/configs unbound
+* [`profile_dns_cache`](#profile_dns_cache): Configures resolv.conf and installs/configs unbound
 * [`profile_dns_cache::config`](#profile_dns_cacheconfig): Configure unbound
 * [`profile_dns_cache::firewall`](#profile_dns_cachefirewall): Open firewall when unbound is being setup as a server
 * [`profile_dns_cache::install`](#profile_dns_cacheinstall): Installs the unbound package
-* [`profile_dns_cache::resolv`](#profile_dns_cacheresolv): Configures DNS using resolv.conf
+* [`profile_dns_cache::resolv`](#profile_dns_cacheresolv): Configures DNS using /etc/resolv.conf.unbound and symlinks to /etc/resolv.conf (to exclude NetworkManager management)
 * [`profile_dns_cache::service`](#profile_dns_cacheservice): Sets up the unbound service
 
 ## Classes
 
 ### <a name="profile_dns_cache"></a>`profile_dns_cache`
 
-Configures /etc/resolv.conf and installs/configs unbound
+Configures resolv.conf and installs/configs unbound
 
 #### Examples
 
@@ -175,7 +175,7 @@ include profile_dns_cache::install
 
 ### <a name="profile_dns_cacheresolv"></a>`profile_dns_cache::resolv`
 
-Configures DNS using resolv.conf
+Configures DNS using /etc/resolv.conf.unbound and symlinks to /etc/resolv.conf (to exclude NetworkManager management)
 
 #### Examples
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# @summary Configures /etc/resolv.conf and installs/configs unbound
+# @summary Configures resolv.conf and installs/configs unbound
 #
 # @author Based on work by Bill Glick; adapted by Jake Rundall.
 #

--- a/manifests/resolv.pp
+++ b/manifests/resolv.pp
@@ -6,13 +6,24 @@
 class profile_dns_cache::resolv {
 
   ## CONFIGURE RESOLV.CONF
+  ## Symlink resolv.conf to stop NetworkManager from meddling
+  ## Reference: SVCPLAN-1814
 
-  file { '/etc/resolv.conf':
+  file { '/etc/resolv.conf.unbound':
     ensure  => 'file',
     content => epp( 'profile_dns_cache/resolv.conf.epp' ),
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
+  }
+
+  file { '/etc/resolv.conf':
+    ensure  => 'link',
+    target   => '/etc/resolv.conf.unbound',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => File['/etc/resolv.conf.unbound'],
   }
 
 }


### PR DESCRIPTION
According to [this Red Hat article](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/manually-configuring-the-etc-resolv-conf-file_configuring-and-managing-networking#replacing-etc-resolv-conf-with-a-symbolic-link-to-manually-configure-dns-settings_manually-configuring-the-etc-resolv-conf-file):

> NetworkManager does not automatically update the DNS configuration if /etc/resolv.conf is a symbolic link

So, to disable NetworkManager's management of resolv.conf in favor of unbound's setup:
- create `/etc/resolv.unbound`
- symlink `/etc/resolv.unbound` -> `/etc/resolv.conf`
- generalize references of `/etc/resolv.conf` to become `resolv.conf`

This pull request will be a draft until tested. I just want to create the PR for the linting and such tests to run.

Long-term, we'll revisit NetworkManager's interaction with Puppet. For this short-term scope, this method should allow for the least amount of changes so that we aren't potentially reverting too much when we circle back to this for refinement.